### PR TITLE
fixed bugs

### DIFF
--- a/src/components/debate-panel.tsx
+++ b/src/components/debate-panel.tsx
@@ -129,7 +129,10 @@ export function DebatePanel({ prd, agents, active = true }: Props) {
     };
 
     run();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      startedRef.current = false;
+    };
   }, [agents, prd, active]);
 
   const synthesizeFinalPRD = async () => {
@@ -221,14 +224,14 @@ export function DebatePanel({ prd, agents, active = true }: Props) {
           </div>
         </ScrollArea>
 
-        {!loading && !finalPRD && (
+        {!loading && !finalPRD && debate.length > 0 && (
           <div className="flex flex-col items-center w-full">
-            <Button 
-              onClick={synthesizeFinalPRD} 
+            <Button
+              onClick={synthesizeFinalPRD}
               className="w-full cursor-pointer hover:opacity-80 transition-opacity"
               variant="default"
               size="lg"
-              disabled={generatingFinal}
+              disabled={generatingFinal || debate.length === 0}
             >
               {generatingFinal ? "Generating Final PRD..." : "Synthesize Final PRD"}
             </Button>
@@ -238,6 +241,12 @@ export function DebatePanel({ prd, agents, active = true }: Props) {
                 <span>Working on synthesis…</span>
               </div>
             )}
+          </div>
+        )}
+
+        {!loading && !finalPRD && debate.length === 0 && (
+          <div className="text-sm text-muted-foreground italic">
+            No debate content was generated. This may be due to rate limiting or a streaming error.
           </div>
         )}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reset debate start ref on cleanup, require debate content before enabling/showing synthesis, and add empty-state message when no debate is generated.
> 
> - **Frontend**
>   - **`src/components/debate-panel.tsx`**
>     - Lifecycle: reset `startedRef.current = false` in `useEffect` cleanup to allow reruns after cancel.
>     - Synthesis UX:
>       - Show "Synthesize Final PRD" button only when `debate.length > 0`.
>       - Disable button when `generatingFinal` or `debate.length === 0`.
>       - Add empty-state notice when no debate content is generated (e.g., rate limit/streaming issues).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e1282cca8c4f10a912a4cc78a745a48e1a64760. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->